### PR TITLE
hal_ethos_u: sync to ethos-u-core-driver (bdd5a80..60b4fbf)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright 2019-2021, 2023-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2019-2021, 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the License); you may
@@ -29,7 +29,7 @@ add_compile_options(-Werror)
 # Build options
 #
 
-set(CMSIS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmsis" CACHE PATH "Path to CMSIS.")
+set(CMSIS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmsis_6" CACHE PATH "Path to CMSIS.")
 
 set(LOG_NAMES err warning info debug)
 set(ETHOSU_LOG_ENABLE ON CACHE BOOL "Toggle driver logs on/off (Defaults to ON)")

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ $ cmake -B build  \
     -DETHOSU_TARGET_NPU_CONFIG=ethos-u<nr>-<macs>
 $ cmake --build build
 ```
+## Compiler flags used
+
+The Arm Ethos-U core driver component adds the -Werror flag in addition
+to the compiler flags specified in the toolchain file, or options passed
+on the command line.
 
 ## Driver APIs
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the user to configure the build to match their system configuration.
 
 One such requirement is to define the target CPU, normally by setting
 `CMAKE_SYSTEM_PROCESSOR`. **Note** that when using the toolchain files provided
-in [core_platform](https://git.mlplatform.org/ml/ethos-u/ethos-u-core-platform.git),
+in [core_platform](https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-core-platform),
 the variable `TARGET_CPU` must be used instead of `CMAKE_SYSTEM_PROCESSOR`.
 
 Target CPU is specified on the form "cortex-m<nr><features>", for example:
@@ -31,7 +31,7 @@ $ cmake -B build  \
 $ cmake --build build
 ```
 
-or when using toolchain files from [core_platform](https://git.mlplatform.org/ml/ethos-u/ethos-u-core-platform.git)
+or when using toolchain files from [core_platform](https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-core-platform)
 
 ```[bash]
 $ cmake -B build  \
@@ -315,12 +315,10 @@ Signed-off-by: Foo Bar foo.bar@example.org
 The contributions will be code reviewed by Arm before they can be accepted into
 the repository.
 
-In order to submit a contribution push your patch to
-`ssh://<GITHUB_USER_ID>@review.mlplatform.org:29418/ml/ethos-u/ethos-u-core-driver`.
-To do this you will need to sign-in to
-[review.mlplatform.org](https://review.mlplatform.org) using a GitHub account
-and add your SSH key under your settings. If there is a problem adding the SSH
-key make sure there is a valid email address in the Email Addresses field.
+In order to submit a contribution, submit a merge request to the
+[core_driver](https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-core-driver)
+repository. To do this you will need to sign-up at [gitlab.arm.com](https://gitlab.arm.com)
+and add your SSH key under your settings.
 
 ## Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,69 +17,17 @@ disclosure when notifications and patches/mitigations are available.
 
 ### Report
 
-For all security issues, contact Arm by email at
-[arm-security@arm.com](mailto:arm-security@arm.com). In the body of the email
+For all security issues, contact Arm Product Security Incident Response Team (PSIRT)
+by email at [psirt@arm.com](mailto:psirt@arm.com). In the body of the email
 include as much information as possible about the issue or vulnerability and any
 additional contact details.
 
 ### Secure submission using PGP
 
 We support and encourage secure submission of vulnerability reports using PGP,
-using the key below. If you would like replies to be encrypted, please provide
-your own public key through a secure mechanism.
-
-~~~none
------BEGIN PGP PUBLIC KEY BLOCK-----
-mQINBFr7/RMBEACjHR5QZL/z1t2aLCRNXLE4KJiQmCo7edU5Be+7MTjIJDzZNu68
-lNEUYRoLexeayif8eC4T19bUsSbGpxHiYsFFjV8ewLXDyDJRRuaBGPfQ5rn/mE6X
-Nvu+9Pputr+mB1R3CXcvrNkhmzPkK7zVM15oeyBMhogqPssuT4OeMduQdip8smfK
-xTMk91RrJTLb+G3eE1tf+81kXBYvzp2e24Sn0/VeYe0IWnBobjVBZk3TmcYxDvz5
-Y47fU9V6cNj3Zq4VYrgxuLoFCA2VtetyiFQm5IYa3Bt3SWcAwihr8nbR2HoNdWyA
-u8wJYYVzSq3hvT5l/IjTHxEcY+6RBq8poDSsftzvX386u9hmw7sJQFlTw6/pUjdr
-gbsZ2ZzRBzKtU17ercpn4kU6VgVP3WRB5HiTFFkEpZuqAznOYaHbMq4dfd/g7Quq
-C0VTbWiJnhku2i+g4BdHHRDtIF6U3aVQAfbrDb1LjVTa65p5ULOeY3HRAWtMNtu/
-Cj8cD98JDanzXtcnisds8vMQ8LZ6iMFChEnF8K4V0eLw9Ju6CMNiFYY7SEBndD/H
-M4KcU4li7mROSbJcshgEbe1SYkxdMuI9eY4DNYxl3VjxoPUGzeqXo/ADFKE9bHsi
-GTyEoij4ku0HspLVKnYHXn/LqHGwEcwjF8zphS+w5cn/e01akYwz5EVSQwARAQAB
-tB1Bcm0gU3VwcG9ydCA8c3VwcG9ydEBhcm0uY29tPokCTgQTAQgAOBYhBN9zqDwZ
-RL/vF0ihcdfNKdz4bBRiBQJa+/0TAhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheA
-AAoJENfNKdz4bBRibK0P/jLlJR/QYypcjb+8BnHT9tCDgcV2KFYXS15VpbSNviN9
-Xs/UOnSadoGUMGCXDyb1PRNn98yUn7JlNR9rtsqPRmkpbo5cuw46ehgxjVlfcHnk
-CttaE8Davx6zo0fyrBib2+oVVW8usi9+uRK4vhhPUicO3oXwzldsVFz+RbpubZxc
-Bg/CZ+dQ2jMKOv1zDtInOG6OBnbQZRAeiWXgGhcIoPZ4zBQOi8nr0+bLcfvMeZi2
-uz6uKnylpXwZbl4ijcG8MKV/ei+7du+SzA9NY0WOT2g3FXDREWUhjKs8bmEZgIx4
-QgvDNpxAUThF+TqQ7zrsA8nT8POvDD0MhN/Z+A3QdPTdcaZFaXzIdxbDg+0FKmzu
-OgtQBH4C01RWrkmZlhO5w7/Qjt0vLlhfyQIL9BW/HeEPtjnH2Hnq8xYnZhlVqJEh
-FJU7F9sMvyiJiKviobFTd6AmpVkhxhcJ3k2L2C03imTsmUwAoejQCXwiYcOhyQ2t
-Z9Nk8YIZTEw2urGFi4HSQPwPq2j/2j7ABJ4rlzJvO6vs5ppGkumvzIIP9JnpVXbp
-wcbK6Ev6KdkX4s14Mzd6Hsd8LpL8t5nHhxUey6G0xKe2eSlHVm5Mlfhoete9UmIZ
-dzIOZkgTgWXlYXRIxwGQ2Pss7pURtofykvLklq4jcobQuHxurl9cteodETfbWk/J
-uQINBFr7/RMBEADWZG8eqt5D22g3T7ehnH/T3fuTX8LPUBnODMWGAEUY8uv64To8
-46odvrXFgWBgCf0sROEyJchc3SGLyR9S4lJsVJRde3QLN3WZkHlB4pSn4IQHFyQd
-wsLQi+S9uggHMPlQ6MNvc5n0P3k5bT9fLUmtJWJ3QVjW7k963ZXpzf1zbQJqs30w
-rlqGUZllfRoYQTfcYxFEaUFhwRJ//skNImWH8Vz+PTnqg2zRtFn3usrBV4GpNvsM
-6jy+YEsSvUa7IY8k4wpPzEhIfqDjGbZxFSQ1H1G+mLUL+DD7oGffej/ZoC86TIdM
-p6ew1rGhJdQBLh9nx+1ADOLWjNo2R0h60u7VR5q/K6V4fwWmeGFipPXZCD92I+nR
-t/cjznwNyD/6J9YrBMF7mbGrS1TyfLaLt4tpdcBnsgqDTodd5OmG65mroXsg/lNO
-7YZdecLZ34krfaLrWTtKkqULXbppB+uQvbVj8p8ONRImn6bZ+iAhnNaH9wJ06ico
-b1F0imJ2SJWnFr6PzPRr0gPStLgu9wrRKheaORwF/H/HxSyPZxNVxFqu81q518A/
-plhub9INQLaxHf/TTjXpqZCcfdNTYUAW8rwbQfW9doSIT4lHY8bJXktb6BsVjkFj
-PzDeYpXeOoTWetQqsEuTdg/F+qg041QBLtNj9Lr3Vy3StgMciRUIP8m0XwARAQAB
-iQI2BBgBCAAgFiEE33OoPBlEv+8XSKFx180p3PhsFGIFAlr7/RMCGwwACgkQ180p
-3PhsFGLWMA//V/XKrnI2YBh/SptUrgg7knPXva45bb7tGSH1fJg8f/wqycOSFFCY
-ES45boA5jlQ3z8uw6BYCz5KeOucGhxAMw+x5EDdxZ33ksY5zqXB35WaMXzEwGYYb
-E113/yhOsTbzu4bBKABSXbJO98MdAWvWpyCpp2MHIR3S9+ycM7/FMZ5xi3czZNRg
-9+WZP+7W4qWhJptQ0kBh5C3N/tiltju5WQ2Y7XIn+5dMOJdtseFS7CNerxXZGAtH
-nfRxaD/4ENdbWOwaVJiVW7+ioUJz09OWgy0gLYSDW+hciDnW1QAaJLpdAbniGZ0S
-JsTmaZla8JnUKqZPgbFfA2OcnH9H+DWc0pHv17c5tJzTMP7rgirgGRX/U2LOzmFZ
-1UxjQj5nn3Oa5frXbIAzb8xKiR0VDaquCM/3sti1AesYiS0Gw0Sqnw8qpFypgFXN
-CKVgYXppIT+TmbDbNJDOB2UycxeI4vbiBwU8fI4qSpW12WsGdAJt/rx3UsyhZ+02
-4aSqDHzhJmtDPQ6lnaKe1fUkC90tgp8loVGmriWQx82jAQMqATVjIklTpE4vm00f
-ocQIWOKEE90mKNEoV6rNbfl5QevmapTVdV/pmrRBzhbsa1uAUS4HZdH0Nf/OXEyv
-yYCr2gCFPymkkRYhPr2w5EgbWyzLaBIwqjyIbXaveuB3DYi2Lhbf64I=
-=EaN7
------END PGP PUBLIC KEY BLOCK-----
-~~~
+with the key found at [Report Security Vulnerability](https://developer.arm.com/support/arm-security-updates/report-security-vulnerabilities).
+If you would like replies to be encrypted, please provide your own public key
+through a secure mechanism.
 
 For more information visit
 <https://developer.arm.com/support/arm-security-updates/report-security-vulnerabilities>

--- a/include/ethosu_driver.h
+++ b/include/ethosu_driver.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2019-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2019-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-FileCopyrightText: Copyright 2025 Alif Semiconductor
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -37,9 +37,9 @@ extern "C" {
  * Defines
  ******************************************************************************/
 
-#define ETHOSU_DRIVER_VERSION_MAJOR 0  ///< Driver major version
-#define ETHOSU_DRIVER_VERSION_MINOR 16 ///< Driver minor version
-#define ETHOSU_DRIVER_VERSION_PATCH 0  ///< Driver patch version
+#define ETHOSU_DRIVER_VERSION_MAJOR 1 ///< Driver major version
+#define ETHOSU_DRIVER_VERSION_MINOR 0 ///< Driver minor version
+#define ETHOSU_DRIVER_VERSION_PATCH 0 ///< Driver patch version
 
 #define ETHOSU_SEMAPHORE_WAIT_FOREVER (UINT64_MAX)
 
@@ -87,8 +87,6 @@ struct ethosu_driver
     size_t fast_memory_size;
     uint32_t power_request_counter;
     bool reserved;
-    uint8_t basep_flush_mask;
-    uint8_t basep_invalidate_mask;
 };
 
 struct ethosu_driver_version
@@ -116,29 +114,26 @@ enum ethosu_request_clients
 void ethosu_irq_handler(struct ethosu_driver *drv);
 
 /**
- * Flush/clean the data cache by address and size.
- * NOTE: It is not recommended to implement this, but let the application code
- *       make sure that any data needed by the NPU is flushed before invoking
- *       an inference.
+ * Flush/clean the data cache
  *
- * Addresses passed to this function must be 32 byte aligned.
+ * Addresses passed to this function must be aligned to cache line size.
  *
- * @param p         32 byte aligned address
- * @param bytes     Size of memory block in bytes
+ * @param base_addr         Array of 32 byte aligned base addresses
+ * @param base_addr_size    Array with size per each base addr entry
+ * @param num_base_addr     Number of base addr entries
  */
-void ethosu_flush_dcache(uint32_t *p, size_t bytes);
+void ethosu_flush_dcache(const uint64_t *base_addr, const size_t *base_addr_size, int num_base_addr);
 
 /**
- * Invalidate the data cache by address and size.
- * NOTE: The driver will only call this for the scratch/tensor arena base
- *       pointer.
+ * Invalidate the data cache
  *
- * Addresses passed to this function must be 32 byte aligned.
+ * Addresses passed to this function must be aligned to cache line size.
  *
- * @param p         32 byte aligned address
- * @param bytes     Size in bytes
+ * @param base_addr         Array of 32 byte aligned base addresses
+ * @param base_addr_size    Array with size per each base addr entry
+ * @param num_base_addr     Number of base addr entries
  */
-void ethosu_invalidate_dcache(uint32_t *p, size_t bytes);
+void ethosu_invalidate_dcache(const uint64_t *base_addr, const size_t *base_addr_size, int num_base_addr);
 
 /**
  * Minimal mutex implementation for baremetal applications. See
@@ -244,15 +239,6 @@ unsigned int ethosu_config_select(uint64_t address, int index);
 /******************************************************************************
  * Prototypes
  ******************************************************************************/
-
-/**
- * Set cache mask for cache flush/clean and invalidation per base pointer.
- *
- * @param drv               Pointer to driver handle
- * @param flush_mask        Base pointer cache flush mask (bit 0 == basep 0)
- * @param invalidate_mask   Base pointer cache invalidation mask (bit 0 == basep 0)
- */
-void ethosu_set_basep_cache_mask(struct ethosu_driver *drv, uint8_t flush_mask, uint8_t invalidate_mask);
 
 /**
  * Initialize the Ethos-U driver.

--- a/include/ethosu_driver.h
+++ b/include/ethosu_driver.h
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2019-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2025 Alif Semiconductor
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the License); you may
@@ -227,6 +228,18 @@ void ethosu_inference_end(struct ethosu_driver *drv, void *user_arg);
  * @return Remapped address
  */
 uint64_t ethosu_address_remap(uint64_t address, int index);
+
+/**
+ * Select configuration for region access.
+ *
+ * Default implementation uses NPU_QCONFIG and NPU_REGIONCFG_n defines.
+ *
+ * @param address   Address of region.
+ * @param index     -1 command stream, 0-n base address index
+ *
+ * @return Configuration to use
+ */
+unsigned int ethosu_config_select(uint64_t address, int index);
 
 /******************************************************************************
  * Prototypes

--- a/src/ethosu_device_u55_u65.c
+++ b/src/ethosu_device_u55_u65.c
@@ -1,5 +1,6 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2019-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2019-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2025 Alif Semiconductor
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the License); you may
@@ -66,6 +67,34 @@ uint64_t __attribute__((weak)) ethosu_address_remap(uint64_t address, int index)
     return address;
 }
 
+unsigned int __attribute__((weak)) ethosu_config_select(uint64_t address, int index)
+{
+    (void)(address);
+    assert(index >= -1 && index <= 7);
+    switch (index)
+    {
+    case -1:
+        return NPU_QCONFIG;
+    default:
+    case 0:
+        return NPU_REGIONCFG_0;
+    case 1:
+        return NPU_REGIONCFG_1;
+    case 2:
+        return NPU_REGIONCFG_2;
+    case 3:
+        return NPU_REGIONCFG_3;
+    case 4:
+        return NPU_REGIONCFG_4;
+    case 5:
+        return NPU_REGIONCFG_5;
+    case 6:
+        return NPU_REGIONCFG_6;
+    case 7:
+        return NPU_REGIONCFG_7;
+    }
+}
+
 bool ethosu_dev_init(struct ethosu_device *dev, void *base_address, uint32_t secure_enable, uint32_t privilege_enable)
 {
     dev->reg        = (volatile struct NPU_REG *)base_address;
@@ -93,23 +122,10 @@ bool ethosu_dev_init(struct ethosu_device *dev, void *base_address, uint32_t sec
 
 enum ethosu_error_codes ethosu_dev_axi_init(struct ethosu_device *dev)
 {
-    struct regioncfg_r rcfg = {0};
-    struct axi_limit0_r l0  = {0};
-    struct axi_limit1_r l1  = {0};
-    struct axi_limit2_r l2  = {0};
-    struct axi_limit3_r l3  = {0};
-
-    dev->reg->QCONFIG.word = NPU_QCONFIG;
-
-    rcfg.region0             = NPU_REGIONCFG_0;
-    rcfg.region1             = NPU_REGIONCFG_1;
-    rcfg.region2             = NPU_REGIONCFG_2;
-    rcfg.region3             = NPU_REGIONCFG_3;
-    rcfg.region4             = NPU_REGIONCFG_4;
-    rcfg.region5             = NPU_REGIONCFG_5;
-    rcfg.region6             = NPU_REGIONCFG_6;
-    rcfg.region7             = NPU_REGIONCFG_7;
-    dev->reg->REGIONCFG.word = rcfg.word;
+    struct axi_limit0_r l0 = {0};
+    struct axi_limit1_r l1 = {0};
+    struct axi_limit2_r l2 = {0};
+    struct axi_limit3_r l3 = {0};
 
     l0.max_beats                = AXI_LIMIT0_MAX_BEATS_BYTES;
     l0.memtype                  = AXI_LIMIT0_MEM_TYPE;
@@ -148,7 +164,8 @@ void ethosu_dev_run_command_stream(struct ethosu_device *dev,
     assert(num_base_addr <= NPU_REG_BASEP_ARRLEN);
 
     struct cmd_r cmd;
-    uint64_t qbase = ethosu_address_remap((uintptr_t)cmd_stream_ptr, -1);
+    struct regioncfg_r rcfg = {0};
+    uint64_t qbase          = ethosu_address_remap((uintptr_t)cmd_stream_ptr, -1);
     assert(qbase <= ADDRESS_MASK);
     LOG_DEBUG("QBASE=0x%016llx, QSIZE=%" PRIu32 ", cmd_stream_ptr=%p", qbase, cms_length, cmd_stream_ptr);
 
@@ -156,7 +173,8 @@ void ethosu_dev_run_command_stream(struct ethosu_device *dev,
 #ifdef ETHOSU65
     dev->reg->QBASE.word[1] = qbase >> 32;
 #endif
-    dev->reg->QSIZE.word = cms_length;
+    dev->reg->QSIZE.word   = cms_length;
+    dev->reg->QCONFIG.word = ethosu_config_select(qbase, -1);
 
     for (int i = 0; i < num_base_addr; i++)
     {
@@ -167,7 +185,10 @@ void ethosu_dev_run_command_stream(struct ethosu_device *dev,
 #ifdef ETHOSU65
         dev->reg->BASEP[i].word[1] = addr >> 32;
 #endif
+        rcfg.word |= ethosu_config_select(addr, i) << (i * 2);
     }
+
+    dev->reg->REGIONCFG.word = rcfg.word;
 
     cmd.word                        = dev->reg->CMD.word & NPU_CMD_PWR_CLK_MASK;
     cmd.transition_to_running_state = 1;

--- a/src/ethosu_device_u85.c
+++ b/src/ethosu_device_u85.c
@@ -1,5 +1,6 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2019-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2019-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2025 Alif Semiconductor
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the License); you may
@@ -56,6 +57,34 @@ uint64_t __attribute__((weak)) ethosu_address_remap(uint64_t address, int index)
     return address;
 }
 
+unsigned int __attribute__((weak)) ethosu_config_select(uint64_t address, int index)
+{
+    (void)(address);
+    assert(index >= -1 && index <= 7);
+    switch (index)
+    {
+    case -1:
+        return NPU_QCONFIG;
+    default:
+    case 0:
+        return NPU_REGIONCFG_0;
+    case 1:
+        return NPU_REGIONCFG_1;
+    case 2:
+        return NPU_REGIONCFG_2;
+    case 3:
+        return NPU_REGIONCFG_3;
+    case 4:
+        return NPU_REGIONCFG_4;
+    case 5:
+        return NPU_REGIONCFG_5;
+    case 6:
+        return NPU_REGIONCFG_6;
+    case 7:
+        return NPU_REGIONCFG_7;
+    }
+}
+
 bool ethosu_dev_init(struct ethosu_device *dev, void *base_address, uint32_t secure_enable, uint32_t privilege_enable)
 {
     dev->reg        = (volatile struct NPU_REG *)base_address;
@@ -79,7 +108,6 @@ bool ethosu_dev_init(struct ethosu_device *dev, void *base_address, uint32_t sec
 
 enum ethosu_error_codes ethosu_dev_axi_init(struct ethosu_device *dev)
 {
-    struct regioncfg_r rcfg = {0};
     struct axi_sram_r axi_s = {0};
     struct axi_ext_r axi_e  = {0};
 
@@ -90,20 +118,6 @@ enum ethosu_error_codes ethosu_dev_axi_init(struct ethosu_device *dev)
     dev->reg->MEM_ATTR[1].word = NPU_MEM_ATTR_1;
     dev->reg->MEM_ATTR[2].word = NPU_MEM_ATTR_2;
     dev->reg->MEM_ATTR[3].word = NPU_MEM_ATTR_3;
-
-    // Set MEM_ATTR entry for command stream
-    dev->reg->QCONFIG.word = NPU_QCONFIG;
-
-    // Set MEM_ATTR entries to use for regions 0-7
-    rcfg.region0             = NPU_REGIONCFG_0;
-    rcfg.region1             = NPU_REGIONCFG_1;
-    rcfg.region2             = NPU_REGIONCFG_2;
-    rcfg.region3             = NPU_REGIONCFG_3;
-    rcfg.region4             = NPU_REGIONCFG_4;
-    rcfg.region5             = NPU_REGIONCFG_5;
-    rcfg.region6             = NPU_REGIONCFG_6;
-    rcfg.region7             = NPU_REGIONCFG_7;
-    dev->reg->REGIONCFG.word = rcfg.word;
 
     // Set AXI limits on SRAM AXI interfaces
     axi_s.max_outstanding_read_m1  = AXI_LIMIT_SRAM_MAX_OUTSTANDING_READ_M1 - 1;
@@ -129,13 +143,15 @@ void ethosu_dev_run_command_stream(struct ethosu_device *dev,
     assert(num_base_addr <= NPU_REG_BASEP_ARRLEN);
 
     struct cmd_r cmd;
-    uint64_t qbase = ethosu_address_remap((uintptr_t)cmd_stream_ptr, -1);
+    struct regioncfg_r rcfg = {0};
+    uint64_t qbase          = ethosu_address_remap((uintptr_t)cmd_stream_ptr, -1);
     assert(qbase <= ADDRESS_MASK);
     LOG_DEBUG("QBASE=0x%016llx, QSIZE=%" PRIu32 ", cmd_stream_ptr=%p", qbase, cms_length, cmd_stream_ptr);
 
     dev->reg->QBASE.word[0] = qbase & 0xffffffff;
     dev->reg->QBASE.word[1] = qbase >> 32;
     dev->reg->QSIZE.word    = cms_length;
+    dev->reg->QCONFIG.word  = ethosu_config_select(qbase, -1);
 
     for (int i = 0; i < num_base_addr; i++)
     {
@@ -144,7 +160,10 @@ void ethosu_dev_run_command_stream(struct ethosu_device *dev,
         LOG_DEBUG("BASEP%d=0x%016llx", i, addr);
         dev->reg->BASEP[i].word[0] = addr & 0xffffffff;
         dev->reg->BASEP[i].word[1] = addr >> 32;
+        rcfg.word |= ethosu_config_select(addr, i) << (i * 2);
     }
+
+    dev->reg->REGIONCFG.word = rcfg.word;
 
     cmd.word                        = dev->reg->CMD.word & NPU_CMD_PWR_CLK_MASK;
     cmd.transition_to_running_state = 1;

--- a/src/ethosu_log.h
+++ b/src/ethosu_log.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2021-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2021, 2023, 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the License); you may
@@ -45,38 +45,45 @@
 #define ETHOSU_LOG_ENABLE 1
 #endif
 
+#define LOG_COMMON_NOP(s, f, ...)                                                                                      \
+    if (0)                                                                                                             \
+    (void)fprintf(s, "%s" f, "", ##__VA_ARGS__)
+
 #if ETHOSU_LOG_ENABLE
 #define LOG_COMMON(s, f, ...) (void)fprintf(s, f, ##__VA_ARGS__)
 #else
-#define LOG_COMMON(s, f, ...)
+#define LOG_COMMON(s, f, ...) LOG_COMMON_NOP(s, f, ##__VA_ARGS__)
 #endif
 
 // Log formatting
-#define LOG(f, ...) LOG_COMMON(stdout, f, ##__VA__ARGS__)
+#define LOG(f, ...) LOG_COMMON(stdout, f, ##__VA_ARGS__)
 
 #if ETHOSU_LOG_SEVERITY >= ETHOSU_LOG_ERR
-#define LOG_ERR(f, ...)                                                                                                \
-    LOG_COMMON(stderr, "E: " f " (%s:%d)\n", ##__VA_ARGS__, strrchr("/" __FILE__, '/') + 1, __LINE__)
+#ifdef __FILE_NAME__
+#define LOG_ERR(f, ...) LOG_COMMON(stderr, "E: %s:%d: " f "\n", __FILE_NAME__, __LINE__, ##__VA_ARGS__)
 #else
-#define LOG_ERR(f, ...)
+#define LOG_ERR(f, ...) LOG_COMMON(stderr, "E: %s:%d: " f "\n", strrchr("/" __FILE__, '/') + 1, __LINE__, ##__VA_ARGS__)
+#endif
+#else
+#define LOG_ERR(f, ...) LOG_COMMON_NOP(stderr, f, ##__VA_ARGS__)
 #endif
 
 #if ETHOSU_LOG_SEVERITY >= ETHOSU_LOG_WARN
 #define LOG_WARN(f, ...) LOG_COMMON(stdout, "W: " f "\n", ##__VA_ARGS__)
 #else
-#define LOG_WARN(f, ...)
+#define LOG_WARN(f, ...) LOG_COMMON_NOP(stdout, f, ##__VA_ARGS__)
 #endif
 
 #if ETHOSU_LOG_SEVERITY >= ETHOSU_LOG_INFO
 #define LOG_INFO(f, ...) LOG_COMMON(stdout, "I: " f "\n", ##__VA_ARGS__)
 #else
-#define LOG_INFO(f, ...)
+#define LOG_INFO(f, ...) LOG_COMMON_NOP(stdout, f, ##__VA_ARGS__)
 #endif
 
 #if ETHOSU_LOG_SEVERITY >= ETHOSU_LOG_DEBUG
 #define LOG_DEBUG(f, ...) LOG_COMMON(stdout, "D: %s(): " f "\n", __FUNCTION__, ##__VA_ARGS__)
 #else
-#define LOG_DEBUG(f, ...)
+#define LOG_DEBUG(f, ...) LOG_COMMON_NOP(stdout, f, ##__VA_ARGS__)
 #endif
 
 #endif


### PR DESCRIPTION
Sync Ethos-U core driver into Zephyr hal_ethos_u (content-only import)

Summary
Content-only import from the canonical Ethos-U core driver into Zephyr’s hal_ethos_u.
No Zephyr-local changes.

Canonical source (truth):
git@gitlab.arm.com:artificial-intelligence/ethos-u/ethos-u-core-driver.git

Commit range imported from canonical: bdd5a80..60b4fbf (7 commits)

60b4fbf  Update SECURITY.md information
5fbe299  Rework cache management
59803b6  Default to use CMSIS v6 from core_software
a85ddcc  Misc updates to ethosu_log.h
db2caeb  Add ethosu_config_select platform hook
7bf44c5  Change ML Platform references to GitLab
bdd5a80  Add compiler flags info to README.md


Context
The former MLPlatform repo ended with 85625e8 (“THIS REPO HAS MOVED AND IS DEPRECATED”).
Development continues on GitLab. This PR imports the above range (up to canonical 60b4fbf) into Zephyr.

Why SHAs differ
During a prior migration/integration the history was rebased/cherry-picked, so commit SHAs differ even when the patch content is identical. This PR contains the content-equivalent changes rebased onto Zephyr main.

```
Mapping (rebased → canonical → Change-Id → subject)

9728949 → bdd5a80 → I96a565b1384e211c4e68f0f11e1578261b6c1925 → Add compiler flags info to README.md
45e807a → 7bf44c5 → Ie0a1023c1fd80de9622bf61992cde6846b9d674e → Change ML Platform references to GitLab
2964f70 → db2caeb → I425ee1ad2598b65a3c891261a7eff00e9565bdbe → Add ethosu_config_select platform hook
a9696ce → a85ddcc → Ic443a6ba6d4f723c9272e605a2d975413ffe9a66 → Misc updates to ethosu_log.h
4c76f5d → 59803b6 → Id66a7e401a134bad6b6b696dbee22546e298b190 → Default to use CMSIS v6 from core_software
124a27f → 5fbe299 → Ibfd755876842edc911fecebf34fa80c22f287ca4 → Rework cache management
9c7d214 → 60b4fbf → I8567ae9e17f2f685ab9d8ce476bfeb8d16481dd7 → Update SECURITY.md information
```
